### PR TITLE
Improved getFieldByName

### DIFF
--- a/common.blocks/form/form.browser.js
+++ b/common.blocks/form/form.browser.js
@@ -55,8 +55,11 @@ provide(BEMDOM.decl(this.name, /** @lends form.prototype */{
      * @returns {Object}
      */
     getFieldByName : function(name) {
-        var needleDom = this.domElem.find('[data-name=' + name + ']');
-        return this.findBlockOn(needleDom, { block : 'form-field' });
+        var foundFields = this.getFields().filter(function(field) {
+            return field.getName() === name;
+        });
+
+        return foundFields.shift();
     },
     /**
      * Returns serialized form data

--- a/common.blocks/form/form.spec.js
+++ b/common.blocks/form/form.spec.js
@@ -27,6 +27,17 @@ describe('form', function() {
         form.getFieldByName('firstName').getName().should.be.eq('firstName');
     });
 
+    it('should find form-field by complex name', function() {
+        BEMDOM.append(form.domElem, BEMHTML.apply({
+            block : 'form-field',
+            name : 'Client[name]',
+            mods : { type : 'input' },
+            content : { block : 'input' }
+        }));
+
+        form.getFieldByName('Client[name]').getName().should.be.eq('Client[name]');
+    });
+
 });
 
 provide();


### PR DESCRIPTION
In our project, we use complex input names like `Model[fieldName]`.
Old method realisation fails with that complex names.